### PR TITLE
don't show the task with the status delivered to client in My Task tab

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -184,6 +184,7 @@ configuration:
       default_value:
         - [task_assignees, is, '{context.user}']
         - [milestone, is, False]
+        - [sg_status_list, is_not, dlvclt]
 
     file_extensions:
         type: list


### PR DESCRIPTION
We want to hide the tasks that are delivered to client to help the artist gain time while searching for the tasks they still need to do