### PR TITLE
Added support for using hooks to resolve the work and publish templates

### DIFF
--- a/hooks/resolve_template.py
+++ b/hooks/resolve_template.py
@@ -1,0 +1,10 @@
+### Squeeze - Default empty hook to resolve work templates
+
+import sgtk
+
+HookClass = sgtk.get_hook_baseclass()
+
+
+class TemplateResolver(HookClass):
+    def execute(self, *args, **kwargs):
+        return None

--- a/hooks/resolve_template.py
+++ b/hooks/resolve_template.py
@@ -1,4 +1,4 @@
-### Squeeze - Default empty hook to resolve work templates
+### Squeeze - Default empty hook to resolve templates
 
 import sgtk
 
@@ -7,4 +7,7 @@ HookClass = sgtk.get_hook_baseclass()
 
 class TemplateResolver(HookClass):
     def execute(self, *args, **kwargs):
+        """
+        :rtype: tank.template.TemplatePath
+        """
         return None

--- a/info.yml
+++ b/info.yml
@@ -95,6 +95,18 @@ configuration:
         description: Specify a hook that will create the task and do any input validation that is
                      required.
 
+    ### Squeeze - Begin - Hook to override the work & publish templates
+    hook_template_work:
+        type: hook
+        default_value: "{self}/resolve_template.py"
+        description: Optional hook to resolve the work_template
+
+    hook_template_publish:
+        type: hook
+        default_value: "{self}/resolve_template.py"
+        description: Optional hook to resolve the publish_template
+    ### Squeeze - End
+
     # General preferences
     #
     entities:

--- a/python/tk_multi_workfiles/work_area.py
+++ b/python/tk_multi_workfiles/work_area.py
@@ -244,6 +244,10 @@ class WorkArea(object):
                              "template_work_area", "template_publish_area"]
         settings_to_find = ["saveas_default_name", "saveas_prefer_version_up",
                             "version_compare_ignore_fields", "file_extensions"]
+        ### Squeeze - Begin
+        # The hooks are resolved as part of the settings in order to extract the values as-is
+        settings_to_find.extend(["hook_template_work", "hook_template_publish"])
+        ### Squeeze - End
         resolved_settings = {}
         if self._context:
             resolved_settings = self._get_settings_for_context(self._context, templates_to_find, settings_to_find)
@@ -258,6 +262,23 @@ class WorkArea(object):
         self.work_template = resolved_settings.get("template_work")
         self.publish_area_template = resolved_settings.get("template_publish_area")
         self.publish_template = resolved_settings.get("template_publish")
+
+        ### Squeeze - Begin
+        # Allow an optional "hook_template_work" to replace the work template
+        work_template_hook = resolved_settings.get("hook_template_work")
+        if work_template_hook:
+            app = sgtk.platform.current_bundle()
+            work_template = app.execute_hook_expression(work_template_hook, None)
+            if work_template:
+                self.work_template = work_template
+        # Allow an optional "hook_template_publish" to replace the publish template
+        publish_template_hook = resolved_settings.get("hook_template_publish")
+        if publish_template_hook:
+            app = sgtk.platform.current_bundle()
+            publish_template = app.execute_hook_expression(publish_template_hook, None)
+            if publish_template:
+                self.publish_template = publish_template
+        ### Squeeze - End
 
         # update other settings:
         self.save_as_default_name = resolved_settings.get("saveas_default_name", "")


### PR DESCRIPTION
This is to help a transition in the Nuke file templates where the version was using 2 digits and we want newer projects to use 3.

The changes have been marked by `### Squeeze` comments.